### PR TITLE
#5 & #6: Clean up results returning

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,5 @@ repos:
     rev: 6.0.0
     hooks:
       - id: flake8
+        args:
+          - --max-line-length=120

--- a/feral_services/jackett.py
+++ b/feral_services/jackett.py
@@ -2,11 +2,15 @@ from __future__ import annotations
 
 import os
 import random
+from itertools import groupby
 
 import requests
 from dotenv import load_dotenv
 from requests.exceptions import Timeout
+
 load_dotenv()
+
+_TOTAL_RESULTS_TO_RETURN = 20
 
 
 def search(query):
@@ -47,11 +51,15 @@ def format_and_filter_results(results, user_id, memory_database):
         results,
         key=lambda k: k.get('Seeders'),
         reverse=True,
-    )[:25]
+    )[:_TOTAL_RESULTS_TO_RETURN]
+
+    unique_results = [
+        next(group) for _, group in groupby(results_by_top_seeds, key=lambda x: x['Guid'])
+    ]
 
     returned_results = []
     memory_database[user_id] = {}
-    for result in reversed(results_by_top_seeds):
+    for result in reversed(unique_results):
         if result['Seeders'] < 1:
             continue
 

--- a/tests/jackett_test.py
+++ b/tests/jackett_test.py
@@ -11,7 +11,7 @@ _SHAWSHANK_RESULTS = [  # noqa
         'TrackerId': '1337x', 'CategoryDesc': 'Movies/HD',
         'BlackholeLink': None,
         'Title': 'The Shawshank Redemption 1994 REMASTERED 1080p BluRay H264 AAC R4RBG TGx',  # noqa
-        'Guid': 'https://example.com',
+        'Guid': 'https://example.com/1',
         'Link': 'https://example.com',
         'Details': 'https://example.com',
         'PublishDate': '2023-04-10T05:00:00',
@@ -30,7 +30,27 @@ _SHAWSHANK_RESULTS = [  # noqa
         'Tracker': 'IPTorrents', 'TrackerId': 'iptorrents',
         'CategoryDesc': 'Movies/BluRay', 'BlackholeLink': None,
         'Title': 'The Shawshank Redemption 1994 REMASTERED 1080p BluRay H264 AAC-LAMA',  # noqa
-        'Guid': 'https://example.com',
+        'Guid': 'https://example.com/2',
+        'Link': 'https://example.com',
+        'Details': 'https://example.com',
+        'PublishDate': '2023-04-09T21:55:13.9457906+00:00',
+        'Catego ry': [2050, 100048], 'Size': 2909840384,
+        'Files': None, 'Grabs': 163,
+        'Description': 'Tags: 9.3 1994 Drama 1080p Uploaded by: Lama',
+        'RageID': None, 'TVDBId': None, 'Imdb': None,
+        'TMDb': None, 'Author': None, 'BookTitle': None,
+        'Seeders': 42, 'Peers': 0, 'Poster': None,
+        'InfoHash': None, 'MagnetUri': None,
+        'MinimumRatio': 1.0, 'MinimumSeedTime': 1209600,
+        'DownloadVolumeFactor': 1.0, 'UploadVolumeFac tor': 1.0,
+        'Gain': 113.82000160217285,
+    },
+    {  # duplicate result for tests noqa
+        'FirstSeen': '0001-01-01T00:00:00',
+        'Tracker': 'IPTorrents', 'TrackerId': 'iptorrents',
+        'CategoryDesc': 'Movies/BluRay', 'BlackholeLink': None,
+        'Title': 'The Shawshank Redemption 1994 REMASTERED 1080p BluRay H264 AAC-LAMA',  # noqa
+        'Guid': 'https://example.com/2',
         'Link': 'https://example.com',
         'Details': 'https://example.com',
         'PublishDate': '2023-04-09T21:55:13.9457906+00:00',
@@ -94,7 +114,7 @@ def test_format_and_filter_results(mocker):
 
     assert isinstance(formatted_results, str)
 
-    expected_result_count_str = 'Results (2/2)'
+    expected_result_count_str = 'Results (2/3)'
     expected_returned_results_str = (
         '/get11111 - IPTorrents, Seeds: 42, Peers: 0, Size: 2.71GB\n'
         'The Shawshank Redemption 1994 REMASTERED 1080p BluRay H264 AAC-LAMA\n\n'  # noqa


### PR DESCRIPTION
- Use constant for results to return rather than a magic number
- Set the results to return to 20 so we can ignore 4096 character limit
- Filter out duplicate results via the Guid
- Update test