### PR TITLE
refactor: improve Jackett search results formatting

### DIFF
--- a/feral_services/jackett.py
+++ b/feral_services/jackett.py
@@ -54,6 +54,7 @@ def format_and_filter_results(results: list, user_id: int, user_id_to_results: d
 
     returned_results = []
     user_id_to_results[user_id] = {}
+
     for result in reversed(results_by_top_seeds):
         if result['Seeders'] < 1:
             continue
@@ -62,7 +63,6 @@ def format_and_filter_results(results: list, user_id: int, user_id_to_results: d
         count = 0
         while req_id in user_id_to_results[user_id] and count < 5:
             req_id = str(random.randint(10000, 99999))
-
             count += 1
             if count > 4:
                 return 'id collision happened?...'
@@ -75,14 +75,20 @@ def format_and_filter_results(results: list, user_id: int, user_id_to_results: d
             'size': round((result['Size'] / 1024 / 1024 / 1024), 2),
         }
 
-        returned_results.append(
-            f"/get{req_id} - {result['Tracker']}, "
-            f"Seeds: {result['Seeders']}, "
-            f"Peers: {result['Peers']}, "
-            f"Size: {round((result['Size'] / 1024 / 1024 / 1024), 2)}GB\n"
-            f"{result['Title']}",
+        details = (
+            f"└─ {result['Tracker']} | "
+            f"Seeds: {format(result['Seeders'], ',')} | "
+            f"Peers: {format(result['Peers'], ',')} | "
+            f"Size: {format(round(result['Size'] / 1024 / 1024 / 1024, 2), '.2f')} GB"
         )
 
-    result_count_str = f'Results ({len(returned_results)}/{len(results)})'
+        formatted_result = (
+            f"/get{req_id} - {result['Title']}\n"
+            f"{details}"
+        )
+
+        returned_results.append(formatted_result)
+
+    result_count = f"Results ({len(returned_results)}/{len(results)})"
     returned_results_str = '\n\n'.join(returned_results)
-    return f'{result_count_str}\n\n{returned_results_str}'
+    return f"{result_count}\n\n{returned_results_str}"

--- a/main.py
+++ b/main.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import contextlib
 import json
 import os
-import re
 import threading
 
 import requests


### PR DESCRIPTION
- Reorganize result display with title on first line and details on second
- Add thousands separator formatting for seeds/peers counts
- Fix GB size formatting to always show 2 decimal places
- Remove unused re import from main.py

```
/search arcane
> Results (3/149)
> 
> /get14492 - Arcane.S02E01.1080p.WEB.H264-SuccessfulCrab[TGx]
> └─ 1337x | Seeds: 1,647 | Peers: 1,337 | Size: 1.62 GB
>
> /get44471 - Arcane.S02E02.1080p.WEB.H264-SuccessfulCrab[TGx]
> └─ 1337x | Seeds: 2,121 | Peers: 1,236 | Size: 1.52 GB
>
> /get37712 - Arcane.S02E03.1080p.WEB.H264-SuccessfulCrab[TGx]
> └─ 1337x | Seeds: 2,159 | Peers: 1,118 | Size: 1.62 GB
```